### PR TITLE
PY-194 Improve the error message in NeptuneRetryError

### DIFF
--- a/src/neptune_query/exceptions.py
+++ b/src/neptune_query/exceptions.py
@@ -206,11 +206,15 @@ class NeptuneRetryError(NeptuneError):
             """
 {h1}NeptuneRetryError: The Neptune server returned an error after {retries} retries, {time:.2f} seconds.{end}
 
-The retry logic is designed to handle rate limiting and network errors. Timeouts for retrying server requests are set
-using environment variables, which can be adjusted to suit your needs, currently set to:
+The retry logic handles rate limiting and network errors. To adjust the timeouts for retrying server requests,
+change the values of the following environment variables, which are currently set to:
 
 NEPTUNE_QUERY_RETRY_SOFT_TIMEOUT={soft_limit}
 NEPTUNE_QUERY_RETRY_HARD_TIMEOUT={hard_limit}
+
+For details, see the docs:
+https://docs.neptune.ai/environment_variables/neptune_query#neptune_query_retry_soft_timeout
+https://docs.neptune.ai/environment_variables/neptune_query#neptune_query_retry_hard_timeout
 
 {status_code_line}
 {content_line}

--- a/src/neptune_query/exceptions.py
+++ b/src/neptune_query/exceptions.py
@@ -206,6 +206,12 @@ class NeptuneRetryError(NeptuneError):
             """
 {h1}NeptuneRetryError: The Neptune server returned an error after {retries} retries, {time:.2f} seconds.{end}
 
+The retry logic is designed to handle rate limiting and network errors. Timeouts for retrying server requests are set
+using environment variables, which can be adjusted to suit your needs, currently set to:
+
+NEPTUNE_QUERY_RETRY_SOFT_TIMEOUT={soft_limit}
+NEPTUNE_QUERY_RETRY_HARD_TIMEOUT={hard_limit}
+
 {status_code_line}
 {content_line}
 """,
@@ -213,6 +219,8 @@ class NeptuneRetryError(NeptuneError):
             time=time,
             status_code_line=f"Last response status: {last_status_code}" if last_status_code is not None else "",
             content_line=f"Last response content: {content_str}" if last_content is not None else "",
+            soft_limit=env.NEPTUNE_QUERY_RETRY_SOFT_TIMEOUT.get(),
+            hard_limit=env.NEPTUNE_QUERY_RETRY_HARD_TIMEOUT.get(),
         )
 
 
@@ -301,7 +309,7 @@ def warn_unsupported_value_type(type_: str) -> None:
     _warned_types.add(type_)
     warnings.warn(
         f"A value of type `{type_}` was returned by your query. This type is not supported by your installed version "
-        "of neptune-fetcher. Values will evaluate to `None` and empty DataFrames. "
-        "Upgrade neptune-fetcher to access this data.",
+        "of neptune-query. Values will evaluate to `None` and empty DataFrames. "
+        "Upgrade neptune-query to access this data.",
         NeptuneWarning,
     )


### PR DESCRIPTION
Improve the error message to tell what the SOFT and HARD timeouts are set to (against the time spent on the request) and how to bump them.

Old message:

<img width="1000" height="119" alt="before" src="https://github.com/user-attachments/assets/1b54a96b-9d20-45a7-bf17-66991058b688" />

New message:

<img width="955" height="283" alt="after" src="https://github.com/user-attachments/assets/3868f753-79ed-4bc2-bcff-66e202968ba2" />

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [x] Did you **ask the docs owner** to review all the user-facing changes?
