### PR TITLE
Disable performance tests on PR

### DIFF
--- a/.github/workflows/tests-performance.yml
+++ b/.github/workflows/tests-performance.yml
@@ -8,13 +8,13 @@ on:
     branches:
       - main
       - dev/.*
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'dev_requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/tests-performance.yml'
+#  pull_request:
+#    paths:
+#      - 'src/**'
+#      - 'tests/**'
+#      - 'dev_requirements.txt'
+#      - 'pyproject.toml'
+#      - '.github/workflows/tests-performance.yml'
 
 jobs:
   test:


### PR DESCRIPTION
Performance tests are not stable enough to block PRs

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
