### PR TITLE
Re-enable test_perf_create_series_dataframe

### DIFF
--- a/tests/performance/test_perf_output_format.py
+++ b/tests/performance/test_perf_output_format.py
@@ -90,7 +90,7 @@ def test_create_metrics_dataframe_with_random_data(
     dict(num_experiments=200, num_paths=50, num_steps=100, min_p0=0.600, max_p80=1.000, max_p100=1.500),
     dict(num_experiments=50, num_paths=200, num_steps=100, min_p0=0.600, max_p80=1.000, max_p100=1.500),
 )
-def xtest_perf_create_series_dataframe(benchmark, num_experiments, num_paths, num_steps):
+def test_perf_create_series_dataframe(benchmark, num_experiments, num_paths, num_steps):
     """Test the performance of create_series_dataframe"""
     series_data = {}
     for exp in range(num_experiments):


### PR DESCRIPTION
The test was disabled by mistake (while performance testing older versions of nq)