### PR TITLE
Optimize `fetch_metrics` fast paths for exact run/attribute lists

### DIFF
--- a/src/neptune_api_codegen/docker.py
+++ b/src/neptune_api_codegen/docker.py
@@ -58,6 +58,9 @@ def run_in_docker(work_dir: Path, dockerfile: str, command: list[str], verbose: 
     image_name = f"neptune-api-codegen_{dockerfile.replace('Dockerfile.', '')}"
     with TemporaryDirectory() as tmpdir:
         shutil.copy(str(dockerfile_path), str(Path(tmpdir) / "Dockerfile"))
+        npm_tools_dir = docker_dir / "npm-tools"
+        if npm_tools_dir.is_dir():
+            shutil.copytree(str(npm_tools_dir), str(Path(tmpdir) / "npm-tools"))
         verbose_run(
             ["docker", "build", "-t", image_name, tmpdir],
             verbose=verbose,

--- a/src/neptune_api_codegen/docker/Dockerfile.generate-openapi
+++ b/src/neptune_api_codegen/docker/Dockerfile.generate-openapi
@@ -2,12 +2,13 @@ FROM node:20-slim
 COPY --from=ghcr.io/astral-sh/uv:0.9.22 /uv /uvx /usr/local/bin/
 COPY --from=ghcr.io/jqlang/jq:1.8.1 /jq /usr/local/bin/
 
+WORKDIR /opt/npm-tools
+COPY npm-tools/package.json npm-tools/package-lock.json ./
+RUN npm ci --omit=dev
+ENV PATH="/opt/npm-tools/node_modules/.bin:${PATH}"
+
 WORKDIR /work
 CMD bash
-
-RUN npm install -g swagger2openapi@7.0.8
-RUN npm install -g openapi-format@1.26.0
-RUN npm install -g @redocly/cli@1.34.3
 
 # Install openapi-python-client via uvx
 RUN uv tool install --python=3.9 openapi-python-client==0.21.5

--- a/src/neptune_api_codegen/docker/npm-tools/package-lock.json
+++ b/src/neptune_api_codegen/docker/npm-tools/package-lock.json
@@ -1,0 +1,3079 @@
+{
+  "name": "neptune-api-codegen-openapi-tools",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "neptune-api-codegen-openapi-tools",
+      "version": "1.0.0",
+      "dependencies": {
+        "@redocly/cli": "1.34.3",
+        "openapi-format": "1.26.0",
+        "swagger2openapi": "7.0.8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+      "license": "MIT"
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
+      "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-transformer": "0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
+      "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.26.0.tgz",
+      "integrity": "sha512-vvVkQLQ/lGGyEy9GT8uFnI047pajSOVnZI2poJqVGD3nJ+B9sFGdlHNnQKophE3lHfnIH0pw2ubrCTjZCgIj+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.26.0.tgz",
+      "integrity": "sha512-DelFGkCdaxA1C/QA0Xilszfr0t4YbGd3DjxiCDPh34lfnFr+VkkrjV9S8ZTJvAzfdKERXhfOxIKBoGPJwoSz7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
+      "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.26.0.tgz",
+      "integrity": "sha512-Fj5IVKrj0yeUwlewCRwzOVcr5avTuNnMHWf7GPc1t6WaT78J6CJyF3saZ/0RkZfdeNO8IcBl/bNcWMVZBMRW8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.17.4",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
+      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.3.tgz",
+      "integrity": "sha512-GJNBTMfm5wTCtH6K+RtPQZuGbqflMclXqAZ5My12tfux6xFDMW1l0MNd5RMpnIS1aeFcDX++P1gnnROWlesj4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@redocly/config": "^0.22.0",
+        "@redocly/openapi-core": "1.34.3",
+        "@redocly/respect-core": "1.34.3",
+        "abort-controller": "^3.0.0",
+        "chokidar": "^3.5.1",
+        "colorette": "^1.2.0",
+        "core-js": "^3.32.1",
+        "dotenv": "^16.4.7",
+        "form-data": "^4.0.0",
+        "get-port-please": "^3.0.1",
+        "glob": "^7.1.6",
+        "handlebars": "^4.7.6",
+        "mobx": "^6.0.4",
+        "pluralize": "^8.0.0",
+        "react": "^17.0.0 || ^18.2.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.2.0 || ^19.0.0",
+        "redoc": "2.5.0",
+        "semver": "^7.5.2",
+        "simple-websocket": "^9.0.0",
+        "styled-components": "^6.0.7",
+        "yargs": "17.0.1"
+      },
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.2.tgz",
+      "integrity": "sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.3.tgz",
+      "integrity": "sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.11.2",
+        "@redocly/config": "^0.22.0",
+        "colorette": "^1.2.0",
+        "https-proxy-agent": "^7.0.5",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^5.0.1",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/respect-core": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.3.tgz",
+      "integrity": "sha512-vo/gu7dRGwTVsRueVSjVk04jOQuL0w22RBJRdRUWkfyse791tYXgMCOx35ijKekL83Q/7Okxf/YX6UY1v5CAug==",
+      "license": "MIT",
+      "dependencies": {
+        "@faker-js/faker": "^7.6.0",
+        "@redocly/ajv": "8.11.2",
+        "@redocly/openapi-core": "1.34.3",
+        "better-ajv-errors": "^1.2.0",
+        "colorette": "^2.0.20",
+        "concat-stream": "^2.0.0",
+        "cookie": "^0.7.2",
+        "dotenv": "16.4.5",
+        "form-data": "4.0.0",
+        "jest-diff": "^29.3.1",
+        "jest-matcher-utils": "^29.3.1",
+        "js-yaml": "4.1.0",
+        "json-pointer": "^0.6.2",
+        "jsonpath-plus": "^10.0.6",
+        "open": "^10.1.0",
+        "openapi-sampler": "^1.6.1",
+        "outdent": "^0.8.0",
+        "set-cookie-parser": "^2.3.5",
+        "undici": "^6.21.1"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/respect-core/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "license": "MIT"
+    },
+    "node_modules/@stoplight/ordered-object-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.5.tgz",
+      "integrity": "sha512-COTiuCU5bgMUtbIFBuyyh2/yVVzlr5Om0v5utQDgBCuQUOPgU1DwoffkTfg4UBQOvByi5foF4w4T+H9CoRe5wg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/types": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+      "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.3.0.tgz",
+      "integrity": "sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.5",
+        "@stoplight/types": "^14.1.1",
+        "@stoplight/yaml-ast-parser": "0.0.50",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.8"
+      }
+    },
+    "node_modules/@stoplight/yaml-ast-parser": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.50.tgz",
+      "integrity": "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/stylis": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
+      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/api-ref-bundler": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/api-ref-bundler/-/api-ref-bundler-0.4.3.tgz",
+      "integrity": "sha512-FHzgrNIg7CHw59tl0GVdc7jng+ORiDGgcm6+EDANKqfMjFQY570GJMT0/89/dYloPN3w7zBTKURnIEcA2sTCXg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-crawl": "0.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/better-ajv-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-1.2.0.tgz",
+      "integrity": "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
+        "chalk": "^4.1.2",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/case-anything": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.10.tgz",
+      "integrity": "sha512-JczJwVrCP0jPKh05McyVsuOg6AYosrB9XWZKbQzXeDAm2ClE/PJE/BcrrQrVyGYH7Jg8V/LDupmyL4kFlVsVFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decko": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+      "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ=="
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
+      "license": "MIT"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "license": "MIT"
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http2-client": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/json-crawl": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/json-crawl/-/json-crawl-0.4.2.tgz",
+      "integrity": "sha512-MOKk9cjtpMrP4H1DmG+PtS7aFWg9OuSqxc/wpFcOE++yVnD5Bi5iKoXD6oqs+kltRwJRgZBYMozRNpQpxD/TJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "license": "MIT",
+      "dependencies": {
+        "foreach": "^2.0.4"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mobx": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
+      "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-9.2.1.tgz",
+      "integrity": "sha512-WJNNm0FB2n0Z0u+jS1QHmmWyV8l2WiAj8V8I/96kbUEN2YbYCoKW+hbbqKKRUBqElu0llxM7nWKehvRIkhBVJw==",
+      "license": "MIT",
+      "dependencies": {
+        "mobx-react-lite": "^4.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/neotraverse": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^3.2.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-linter": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@exodus/schemasafe": "^1.0.0-rc.2",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-schema-walker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.8",
+        "oas-linter": "^3.2.2",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "reftools": "^1.1.9",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-format": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/openapi-format/-/openapi-format-1.26.0.tgz",
+      "integrity": "sha512-suYhmy2LhvYpIQYK7u3Ny2kL/XprSVkemuE+Yf55sEm4lrAYk8J/FDPpGzO4JRCXgN9kbbTqctI2RmZCYlnvqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stoplight/yaml": "^4.3.0",
+        "api-ref-bundler": "^0.4.3",
+        "case-anything": "2.1.10",
+        "commander": "^7.2.0",
+        "jsonpath-plus": "^10.3.0",
+        "neotraverse": "^0.6.18"
+      },
+      "bin": {
+        "openapi-format": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/openapi-sampler": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.0.tgz",
+      "integrity": "sha512-fWq32F5vqGpgRJYIarC/9Y1wC9tKnRDcCOjsDJ7MIcSv2HsE7kNifcXIZ8FVtNStBUWxYrEk/MKqVF0SwZ5gog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^5.3.4",
+        "json-pointer": "0.6.2"
+      }
+    },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
+      "license": "MIT"
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/perfect-scrollbar": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz",
+      "integrity": "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-tabs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.0.tgz",
+      "integrity": "sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redoc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.5.0.tgz",
+      "integrity": "sha512-NpYsOZ1PD9qFdjbLVBZJWptqE+4Y6TkUuvEOqPUmoH7AKOmPcE+hYjotLxQNTqVoWL4z0T2uxILmcc8JGDci+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.4.0",
+        "classnames": "^2.3.2",
+        "decko": "^1.2.0",
+        "dompurify": "^3.2.4",
+        "eventemitter3": "^5.0.1",
+        "json-pointer": "^0.6.2",
+        "lunr": "^2.3.9",
+        "mark.js": "^8.11.1",
+        "marked": "^4.3.0",
+        "mobx-react": "^9.1.1",
+        "openapi-sampler": "^1.5.0",
+        "path-browserify": "^1.0.1",
+        "perfect-scrollbar": "^1.5.5",
+        "polished": "^4.2.2",
+        "prismjs": "^1.29.0",
+        "prop-types": "^15.8.1",
+        "react-tabs": "^6.0.2",
+        "slugify": "~1.4.7",
+        "stickyfill": "^1.1.1",
+        "swagger2openapi": "^7.0.8",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=6.9",
+        "npm": ">=3.0.0"
+      },
+      "peerDependencies": {
+        "core-js": "^3.1.4",
+        "mobx": "^6.0.4",
+        "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
+      }
+    },
+    "node_modules/reftools": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
+    },
+    "node_modules/should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+      "license": "MIT"
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "license": "MIT"
+    },
+    "node_modules/simple-websocket": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+      "integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "queue-microtask": "^1.2.2",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0",
+        "ws": "^7.4.2"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
+      "integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stickyfill": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+      "integrity": "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/styled-components": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.8.tgz",
+      "integrity": "sha512-Kq/W41AKQloOqKM39zfaMdJ4BcYDw/N5CIq4/GTI0YjU6pKcZ1KKhk6b4du0a+6RA9pIfOP/eu94Ge7cu+PDCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "@emotion/unitless": "0.10.0",
+        "@types/stylis": "4.2.7",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.6",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/swagger2openapi": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.8",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "oas-validator": "^5.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "boast": "boast.js",
+        "oas-validate": "oas-validate.js",
+        "swagger2openapi": "swagger2openapi.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/src/neptune_api_codegen/docker/npm-tools/package.json
+++ b/src/neptune_api_codegen/docker/npm-tools/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "neptune-api-codegen-openapi-tools",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Pinned npm CLI tools for OpenAPI client generation",
+  "dependencies": {
+    "@redocly/cli": "1.34.3",
+    "openapi-format": "1.26.0",
+    "swagger2openapi": "7.0.8"
+  },
+  "overrides": {
+    "styled-components": "6.3.8"
+  }
+}

--- a/src/neptune_query/__init__.py
+++ b/src/neptune_query/__init__.py
@@ -232,6 +232,8 @@ def fetch_metrics(
         project_identifier=project_identifier,
         filter_=experiments_filter,
         attributes=attributes_filter,
+        exact_run_ids=None,
+        exact_attribute_names=attributes if isinstance(attributes, list) else None,
         include_time=include_time,
         step_range=step_range,
         lineage_to_the_root=lineage_to_the_root,

--- a/src/neptune_query/internal/composition/fetch_metrics.py
+++ b/src/neptune_query/internal/composition/fetch_metrics.py
@@ -136,6 +136,37 @@ def _fetch_metrics(
     exact_run_ids: Optional[list[str]] = None,
     exact_attribute_names: Optional[list[str]] = None,
 ) -> tuple[dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], dict[identifiers.SysId, str]]:
+    """Fetch float-series points for runs/experiments and merge split results.
+
+    Shared pipeline:
+    1. Build run/experiment targets as sys ids.
+    2. Build run-attribute pairs either from exact attribute names or from
+       attribute definitions filtered to ``float_series``.
+    3. Fetch series values in concurrent splits and merge chunked outputs.
+    4. ``exact_attribute_names`` optimization from step 2 applies to both
+       runs and experiments, but only after target sys ids are known.
+
+    RUN fast path:
+    - Triggered only when ``container_type == RUN`` and both
+      ``exact_run_ids`` and ``exact_attribute_names`` are provided.
+    - Skips container search and attribute-definition lookup (full fast path).
+    - Uses the deduplicated cartesian product of run ids and attribute names to
+      build ``RunAttributeDefinition`` directly.
+    - Stores each exact run id as ``RunIdentifier.custom_run_id`` so holder
+      serialization uses custom ids.
+    - Returns ``{SysId(run_id): run_id}`` as the label mapping.
+
+    Default path (experiments and non-fast-path runs):
+    - Fetches matching containers and labels via
+      ``search.fetch_sys_id_labels(container_type)``.
+    - For each sys-id page, if ``exact_attribute_names`` are provided, skips
+      ``fetch_attribute_definitions_split`` and builds
+      ``RunAttributeDefinition`` directly.
+    - Otherwise resolves definitions via ``fetch_attribute_definitions_split``.
+    - Then fetches series values.
+    - Holder serialization uses sys ids by default.
+    """
+
     def merge_results(
         results: Generator[dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], None, None],
     ) -> dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]:
@@ -148,7 +179,6 @@ def _fetch_metrics(
     def fetch_metrics_for_run_attribute_definitions(
         *,
         run_attribute_definitions: Iterable[identifiers.RunAttributeDefinition],
-        run_identifier_mode: Literal["sys_id", "custom_run_id"] = "sys_id",
     ) -> concurrency.OUT:
         return concurrency.generate_concurrently(
             items=split.split_series_attributes(items=run_attribute_definitions),
@@ -162,22 +192,25 @@ def _fetch_metrics(
                     container_type=container_type,
                     step_range=step_range,
                     tail_limit=tail_limit,
-                    run_identifier_mode=run_identifier_mode,
                 )
             ),
         )
 
-    def downstream_for_sys_ids(
+    def fetch_metrics_for_sys_ids(
         *,
         sys_ids: list[identifiers.SysId],
         deduplicated_exact_attribute_names: Optional[set[str]],
-        run_identifier_mode: Literal["sys_id", "custom_run_id"] = "sys_id",
+        custom_run_ids: Optional[dict[identifiers.SysId, identifiers.CustomRunId]] = None,
     ) -> concurrency.OUT:
         if deduplicated_exact_attribute_names is not None:
             return fetch_metrics_for_run_attribute_definitions(
                 run_attribute_definitions=(
                     identifiers.RunAttributeDefinition(
-                        run_identifier=identifiers.RunIdentifier(project_identifier, sys_id),
+                        run_identifier=identifiers.RunIdentifier(
+                            project_identifier=project_identifier,
+                            sys_id=sys_id,
+                            custom_run_id=custom_run_ids[sys_id] if custom_run_ids is not None else None,
+                        ),
                         attribute_definition=identifiers.AttributeDefinition(
                             name=attribute_name,
                             type="float_series",
@@ -186,7 +219,6 @@ def _fetch_metrics(
                     for sys_id in sys_ids
                     for attribute_name in deduplicated_exact_attribute_names
                 ),
-                run_identifier_mode=run_identifier_mode,
             )
 
         return fetch_attribute_definitions_split(
@@ -206,7 +238,6 @@ def _fetch_metrics(
                     for definition in definitions_page.items
                     if definition.type == "float_series"
                 ),
-                run_identifier_mode=run_identifier_mode,
             ),
         )
 
@@ -216,11 +247,14 @@ def _fetch_metrics(
         run_sys_id_label_mapping: dict[identifiers.SysId, str] = {
             identifiers.SysId(run_id): run_id for run_id in deduplicated_run_ids
         }
+        custom_run_ids_by_sys_id = {
+            identifiers.SysId(run_id): identifiers.CustomRunId(run_id) for run_id in run_sys_id_label_mapping.values()
+        }
 
-        output = downstream_for_sys_ids(
+        output = fetch_metrics_for_sys_ids(
             sys_ids=[identifiers.SysId(run_id) for run_id in run_sys_id_label_mapping.values()],
             deduplicated_exact_attribute_names=deduplicated_exact_attribute_names,
-            run_identifier_mode="custom_run_id",
+            custom_run_ids=custom_run_ids_by_sys_id,
         )
         return merge_results(concurrency.gather_results(output)), run_sys_id_label_mapping
 
@@ -241,7 +275,7 @@ def _fetch_metrics(
     output = concurrency.generate_concurrently(
         items=go_fetch_sys_attrs(),
         executor=executor,
-        downstream=lambda sys_ids: downstream_for_sys_ids(
+        downstream=lambda sys_ids: fetch_metrics_for_sys_ids(
             sys_ids=sys_ids,
             deduplicated_exact_attribute_names=deduplicated_exact_attribute_names,
         ),

--- a/src/neptune_query/internal/composition/fetch_metrics.py
+++ b/src/neptune_query/internal/composition/fetch_metrics.py
@@ -136,35 +136,34 @@ def _fetch_metrics(
     exact_run_ids: Optional[list[str]] = None,
     exact_attribute_names: Optional[list[str]] = None,
 ) -> tuple[dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], dict[identifiers.SysId, str]]:
-    """Fetch float-series points for runs/experiments and merge split results.
+    """Fetch float-series metric points for matching containers (runs/experiments).
 
-    Shared pipeline:
-    1. Build run/experiment targets as sys ids.
-    2. Build run-attribute pairs either from exact attribute names or from
-       attribute definitions filtered to ``float_series``.
-    3. Fetch series values in concurrent splits and merge chunked outputs.
-    4. ``exact_attribute_names`` optimization from step 2 applies to both
-       runs and experiments, but only after target sys ids are known.
+    This function resolves the target containers, determines which attributes to
+    query (either explicitly or by filtering to ``float_series`` definitions),
+    fetches series values concurrently in splits, and merges chunked results.
 
-    RUN fast path:
-    - Triggered only when ``container_type == RUN`` and both
-      ``exact_run_ids`` and ``exact_attribute_names`` are provided.
-    - Skips container search and attribute-definition lookup (full fast path).
-    - Uses the deduplicated cartesian product of run ids and attribute names to
-      build ``RunAttributeDefinition`` directly.
-    - Stores each exact run id as ``RunIdentifier.custom_run_id`` so holder
-      serialization uses custom ids.
-    - Returns ``{SysId(run_id): run_id}`` as the label mapping.
-
+    Behavior
+    --------
     Default path (experiments and non-fast-path runs):
-    - Fetches matching containers and labels via
-      ``search.fetch_sys_id_labels(container_type)``.
-    - For each sys-id page, if ``exact_attribute_names`` are provided, skips
-      ``fetch_attribute_definitions_split`` and builds
-      ``RunAttributeDefinition`` directly.
-    - Otherwise resolves definitions via ``fetch_attribute_definitions_split``.
-    - Then fetches series values.
-    - Holder serialization uses sys ids by default.
+      1) Search for matching containers and build a ``SysId -> label`` mapping.
+      2) Determine run-attribute pairs:
+         - If ``exact_attribute_names`` is provided, build attribute definitions
+           directly (skips attribute-definition lookup).
+         - Otherwise, resolve attribute definitions via
+           ``fetch_attribute_definitions_split`` and keep only ``float_series``.
+      3) Fetch values via ``fetch_multiple_series_values`` concurrently and merge
+         the split outputs.
+
+    Run fast path:
+      Activated only when:
+        - ``container_type == ContainerType.RUN``, and
+        - both ``exact_run_ids`` and ``exact_attribute_names`` are provided.
+      In this mode the function skips container search and definition lookup.
+      It deduplicates run ids and attribute names, builds the cartesian product
+      of ``(run_id, attribute_name)`` into ``RunAttributeDefinition`` objects,
+      and stores each provided run id as ``RunIdentifier.custom_run_id`` so that
+      downstream/holder serialization uses custom ids rather than sys ids.
+      The returned label mapping is ``{SysId(run_id): run_id}``.
     """
 
     def merge_results(

--- a/src/neptune_query/internal/composition/fetch_metrics.py
+++ b/src/neptune_query/internal/composition/fetch_metrics.py
@@ -202,21 +202,25 @@ def _fetch_metrics(
         custom_run_ids: Optional[dict[identifiers.SysId, identifiers.CustomRunId]] = None,
     ) -> concurrency.OUT:
         if deduplicated_exact_attribute_names is not None:
-            return fetch_metrics_for_run_attribute_definitions(
-                run_attribute_definitions=(
-                    identifiers.RunAttributeDefinition(
-                        run_identifier=identifiers.RunIdentifier(
-                            project_identifier=project_identifier,
-                            sys_id=sys_id,
-                            custom_run_id=custom_run_ids[sys_id] if custom_run_ids is not None else None,
-                        ),
-                        attribute_definition=identifiers.AttributeDefinition(
-                            name=attribute_name,
-                            type="float_series",
-                        ),
-                    )
-                    for sys_id in sys_ids
-                    for attribute_name in deduplicated_exact_attribute_names
+            return concurrency.generate_concurrently(
+                items=split.split_sys_ids(sys_ids),
+                executor=executor,
+                downstream=lambda sys_id_batch: fetch_metrics_for_run_attribute_definitions(
+                    run_attribute_definitions=(
+                        identifiers.RunAttributeDefinition(
+                            run_identifier=identifiers.RunIdentifier(
+                                project_identifier=project_identifier,
+                                sys_id=sys_id,
+                                custom_run_id=custom_run_ids[sys_id] if custom_run_ids is not None else None,
+                            ),
+                            attribute_definition=identifiers.AttributeDefinition(
+                                name=attribute_name,
+                                type="float_series",
+                            ),
+                        )
+                        for sys_id in sys_id_batch
+                        for attribute_name in deduplicated_exact_attribute_names
+                    ),
                 ),
             )
 

--- a/src/neptune_query/internal/composition/fetch_metrics.py
+++ b/src/neptune_query/internal/composition/fetch_metrics.py
@@ -19,6 +19,7 @@ from typing import (
     Iterable,
     Literal,
     Optional,
+    cast,
 )
 
 import pandas as pd
@@ -54,6 +55,8 @@ from ..retrieval.metrics import (
 from ..retrieval.search import ContainerType
 
 __all__ = ("fetch_metrics",)
+
+RunLabelIdentifier = identifiers.SysId | identifiers.CustomRunId
 
 
 def fetch_metrics(
@@ -135,7 +138,7 @@ def _fetch_metrics(
     container_type: ContainerType,
     exact_run_ids: Optional[list[str]] = None,
     exact_attribute_names: Optional[list[str]] = None,
-) -> tuple[dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], dict[identifiers.SysId, str]]:
+) -> tuple[dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], dict[RunLabelIdentifier, str]]:
     """Fetch float-series metric points for matching containers (runs/experiments).
 
     This function resolves the target containers, determines which attributes to
@@ -161,9 +164,8 @@ def _fetch_metrics(
       In this mode the function skips container search and definition lookup.
       It deduplicates run ids and attribute names, builds the cartesian product
       of ``(run_id, attribute_name)`` into ``RunAttributeDefinition`` objects,
-      and stores each provided run id as ``RunIdentifier.custom_run_id`` so that
-      downstream/holder serialization uses custom ids rather than sys ids.
-      The returned label mapping is ``{SysId(run_id): run_id}``.
+      and stores each provided run id as ``RunIdentifier.custom_run_id``.
+      The returned label mapping is ``{CustomRunId(run_id): run_id}``.
     """
 
     def merge_results(
@@ -195,34 +197,51 @@ def _fetch_metrics(
             ),
         )
 
-    def fetch_metrics_for_sys_ids(
+    def _make_run_identifier(
         *,
-        sys_ids: list[identifiers.SysId],
+        run_id: identifiers.SysId | identifiers.CustomRunId,
+        identifiers_are_custom_run_ids: bool,
+    ) -> identifiers.RunIdentifier:
+        if identifiers_are_custom_run_ids:
+            return identifiers.RunIdentifier(
+                project_identifier=project_identifier,
+                custom_run_id=cast(identifiers.CustomRunId, run_id),
+            )
+        return identifiers.RunIdentifier(
+            project_identifier=project_identifier,
+            sys_id=cast(identifiers.SysId, run_id),
+        )
+
+    def fetch_metrics_for_run_ids(
+        *,
+        run_ids: list[identifiers.SysId | identifiers.CustomRunId],
         deduplicated_exact_attribute_names: Optional[set[str]],
-        custom_run_ids: Optional[dict[identifiers.SysId, identifiers.CustomRunId]] = None,
+        identifiers_are_custom_run_ids: bool = False,
     ) -> concurrency.OUT:
         if deduplicated_exact_attribute_names is not None:
             return concurrency.generate_concurrently(
-                items=split.split_sys_ids(sys_ids),
+                items=split.split_sys_ids(cast(list[identifiers.SysId], run_ids)),
                 executor=executor,
-                downstream=lambda sys_id_batch: fetch_metrics_for_run_attribute_definitions(
+                downstream=lambda run_id_batch: fetch_metrics_for_run_attribute_definitions(
                     run_attribute_definitions=(
                         identifiers.RunAttributeDefinition(
-                            run_identifier=identifiers.RunIdentifier(
-                                project_identifier=project_identifier,
-                                sys_id=sys_id,
-                                custom_run_id=custom_run_ids[sys_id] if custom_run_ids is not None else None,
+                            run_identifier=_make_run_identifier(
+                                run_id=run_id,
+                                identifiers_are_custom_run_ids=identifiers_are_custom_run_ids,
                             ),
                             attribute_definition=identifiers.AttributeDefinition(
                                 name=attribute_name,
                                 type="float_series",
                             ),
                         )
-                        for sys_id in sys_id_batch
+                        for run_id in run_id_batch
                         for attribute_name in deduplicated_exact_attribute_names
                     ),
                 ),
             )
+
+        if identifiers_are_custom_run_ids:
+            raise ValueError("Custom run ids require exact attribute names")
 
         return fetch_attribute_definitions_split(
             client=client,
@@ -230,7 +249,7 @@ def _fetch_metrics(
             attribute_filter=attributes,
             executor=executor,
             fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
-            sys_ids=sys_ids,
+            sys_ids=cast(list[identifiers.SysId], run_ids),
             downstream=lambda sys_ids_split, definitions_page: fetch_metrics_for_run_attribute_definitions(
                 run_attribute_definitions=(
                     identifiers.RunAttributeDefinition(
@@ -246,22 +265,19 @@ def _fetch_metrics(
 
     deduplicated_exact_attribute_names = set(exact_attribute_names) if exact_attribute_names is not None else None
     if container_type == ContainerType.RUN and exact_run_ids is not None and exact_attribute_names is not None:
-        deduplicated_run_ids = set(exact_run_ids)
-        run_sys_id_label_mapping: dict[identifiers.SysId, str] = {
-            identifiers.SysId(run_id): run_id for run_id in deduplicated_run_ids
-        }
-        custom_run_ids_by_sys_id = {
-            identifiers.SysId(run_id): identifiers.CustomRunId(run_id) for run_id in run_sys_id_label_mapping.values()
+        deduplicated_run_ids = {identifiers.CustomRunId(run_id) for run_id in exact_run_ids}
+        run_label_mapping: dict[identifiers.CustomRunId, str] = {
+            run_id: str(run_id) for run_id in deduplicated_run_ids
         }
 
-        output = fetch_metrics_for_sys_ids(
-            sys_ids=[identifiers.SysId(run_id) for run_id in run_sys_id_label_mapping.values()],
+        output = fetch_metrics_for_run_ids(
+            run_ids=list(run_label_mapping.keys()),
             deduplicated_exact_attribute_names=deduplicated_exact_attribute_names,
-            custom_run_ids=custom_run_ids_by_sys_id,
+            identifiers_are_custom_run_ids=True,
         )
-        return merge_results(concurrency.gather_results(output)), run_sys_id_label_mapping
+        return merge_results(concurrency.gather_results(output)), run_label_mapping
 
-    sys_id_label_mapping: dict[identifiers.SysId, str] = {}
+    sys_id_label_mapping: dict[RunLabelIdentifier, str] = {}
 
     def go_fetch_sys_attrs() -> Generator[list[identifiers.SysId], None, None]:
         for page in search.fetch_sys_id_labels(container_type)(
@@ -278,8 +294,8 @@ def _fetch_metrics(
     output = concurrency.generate_concurrently(
         items=go_fetch_sys_attrs(),
         executor=executor,
-        downstream=lambda sys_ids: fetch_metrics_for_sys_ids(
-            sys_ids=sys_ids,
+        downstream=lambda sys_ids: fetch_metrics_for_run_ids(
+            run_ids=sys_ids,
             deduplicated_exact_attribute_names=deduplicated_exact_attribute_names,
         ),
     )

--- a/src/neptune_query/internal/composition/fetch_metrics.py
+++ b/src/neptune_query/internal/composition/fetch_metrics.py
@@ -19,6 +19,7 @@ from typing import (
     Iterable,
     Literal,
     Optional,
+    Sequence,
     cast,
 )
 
@@ -214,7 +215,7 @@ def _fetch_metrics(
 
     def fetch_metrics_for_run_ids(
         *,
-        run_ids: list[identifiers.SysId | identifiers.CustomRunId],
+        run_ids: Sequence[identifiers.SysId | identifiers.CustomRunId],
         deduplicated_exact_attribute_names: Optional[set[str]],
         identifiers_are_custom_run_ids: bool = False,
     ) -> concurrency.OUT:
@@ -266,9 +267,7 @@ def _fetch_metrics(
     deduplicated_exact_attribute_names = set(exact_attribute_names) if exact_attribute_names is not None else None
     if container_type == ContainerType.RUN and exact_run_ids is not None and exact_attribute_names is not None:
         deduplicated_run_ids = {identifiers.CustomRunId(run_id) for run_id in exact_run_ids}
-        run_label_mapping: dict[identifiers.CustomRunId, str] = {
-            run_id: str(run_id) for run_id in deduplicated_run_ids
-        }
+        run_label_mapping: dict[RunLabelIdentifier, str] = {run_id: str(run_id) for run_id in deduplicated_run_ids}
 
         output = fetch_metrics_for_run_ids(
             run_ids=list(run_label_mapping.keys()),

--- a/src/neptune_query/internal/composition/fetch_table.py
+++ b/src/neptune_query/internal/composition/fetch_table.py
@@ -166,7 +166,10 @@ def fetch_table(
         )
         for attribute_values_page in attribute_value_pages:
             for attribute_value in attribute_values_page.items:
-                result_by_id[attribute_value.run_identifier.sys_id].append(attribute_value)
+                run_sys_id = attribute_value.run_identifier.sys_id
+                if run_sys_id is None:
+                    raise ValueError("Expected sys_id in run identifier when building table rows")
+                result_by_id[run_sys_id].append(attribute_value)
 
     return create_runs_table(
         table_rows=[

--- a/src/neptune_query/internal/identifiers.py
+++ b/src/neptune_query/internal/identifiers.py
@@ -24,13 +24,21 @@ CustomRunId = NewType("CustomRunId", str)  # an uuid
 @dataclass(frozen=True)
 class RunIdentifier:
     project_identifier: ProjectIdentifier
-    sys_id: SysId
+    sys_id: SysId | None = None
     custom_run_id: CustomRunId | None = None
+
+    def __post_init__(self) -> None:
+        has_sys_id = self.sys_id is not None
+        has_custom_run_id = self.custom_run_id is not None
+        if has_sys_id == has_custom_run_id:
+            raise ValueError("Exactly one of sys_id and custom_run_id must be provided")
 
     def __str__(self) -> str:
         if self.custom_run_id is not None:
             return f"CUSTOM/{self.project_identifier}/{self.custom_run_id}"
-        return f"{self.project_identifier}/{self.sys_id}"
+        if self.sys_id is not None:
+            return f"{self.project_identifier}/{self.sys_id}"
+        raise ValueError("RunIdentifier must have either sys_id or custom_run_id")
 
 
 @dataclass(frozen=True)

--- a/src/neptune_query/internal/identifiers.py
+++ b/src/neptune_query/internal/identifiers.py
@@ -25,8 +25,11 @@ CustomRunId = NewType("CustomRunId", str)  # an uuid
 class RunIdentifier:
     project_identifier: ProjectIdentifier
     sys_id: SysId
+    custom_run_id: CustomRunId | None = None
 
     def __str__(self) -> str:
+        if self.custom_run_id is not None:
+            return f"CUSTOM/{self.project_identifier}/{self.custom_run_id}"
         return f"{self.project_identifier}/{self.sys_id}"
 
 

--- a/src/neptune_query/internal/output_format.py
+++ b/src/neptune_query/internal/output_format.py
@@ -57,6 +57,8 @@ __all__ = (
     "create_metric_buckets_dataframe",
 )
 
+RunLabelIdentifier = identifiers.SysId | identifiers.CustomRunId
+
 
 @dataclass
 class TableRow:
@@ -188,7 +190,7 @@ def _convert_table_to_dataframe(
 
 def create_metrics_dataframe(
     metrics_data: dict[identifiers.RunAttributeDefinition, list[metrics.FloatPointValue]],
-    sys_id_label_mapping: dict[identifiers.SysId, str],
+    sys_id_label_mapping: dict[RunLabelIdentifier, str],
     *,
     type_suffix_in_column_names: bool,
     include_point_previews: bool,
@@ -225,20 +227,28 @@ def create_metrics_dataframe(
     """
 
     path_mapping: dict[str, int] = {}
-    sys_id_mapping: dict[str, int] = {}
+    run_label_mapping: dict[RunLabelIdentifier, int] = {}
     label_mapping: list[str] = []
 
+    def run_label_id(run_identifier: identifiers.RunIdentifier) -> RunLabelIdentifier:
+        if run_identifier.sys_id is not None:
+            return run_identifier.sys_id
+        if run_identifier.custom_run_id is not None:
+            return run_identifier.custom_run_id
+        raise ValueError("RunIdentifier must have either sys_id or custom_run_id")
+
     for run_attr_definition in metrics_data:
-        if run_attr_definition.run_identifier.sys_id not in sys_id_mapping:
-            sys_id_mapping[run_attr_definition.run_identifier.sys_id] = len(sys_id_mapping)
-            label_mapping.append(sys_id_label_mapping[run_attr_definition.run_identifier.sys_id])
+        run_label_id_ = run_label_id(run_attr_definition.run_identifier)
+        if run_label_id_ not in run_label_mapping:
+            run_label_mapping[run_label_id_] = len(run_label_mapping)
+            label_mapping.append(sys_id_label_mapping[run_label_id_])
 
         if run_attr_definition.attribute_definition.name not in path_mapping:
             path_mapping[run_attr_definition.attribute_definition.name] = len(path_mapping)
 
     def generate_categorized_rows() -> Generator[Tuple, None, None]:
         for attribute, points in metrics_data.items():
-            exp_category = sys_id_mapping[attribute.run_identifier.sys_id]
+            exp_category = run_label_mapping[run_label_id(attribute.run_identifier)]
             path_category = path_mapping[attribute.attribute_definition.name]
 
             for point in points:

--- a/src/neptune_query/internal/output_format.py
+++ b/src/neptune_query/internal/output_format.py
@@ -60,6 +60,20 @@ __all__ = (
 RunLabelIdentifier = identifiers.SysId | identifiers.CustomRunId
 
 
+def _run_label_id(run_identifier: identifiers.RunIdentifier) -> RunLabelIdentifier:
+    if run_identifier.sys_id is not None:
+        return run_identifier.sys_id
+    if run_identifier.custom_run_id is not None:
+        return run_identifier.custom_run_id
+    raise ValueError("RunIdentifier must have either sys_id or custom_run_id")
+
+
+def _require_sys_id(run_identifier: identifiers.RunIdentifier) -> identifiers.SysId:
+    if run_identifier.sys_id is None:
+        raise ValueError("RunIdentifier must have sys_id")
+    return run_identifier.sys_id
+
+
 @dataclass
 class TableRow:
     values: list[AttributeValue]
@@ -230,15 +244,8 @@ def create_metrics_dataframe(
     run_label_mapping: dict[RunLabelIdentifier, int] = {}
     label_mapping: list[str] = []
 
-    def run_label_id(run_identifier: identifiers.RunIdentifier) -> RunLabelIdentifier:
-        if run_identifier.sys_id is not None:
-            return run_identifier.sys_id
-        if run_identifier.custom_run_id is not None:
-            return run_identifier.custom_run_id
-        raise ValueError("RunIdentifier must have either sys_id or custom_run_id")
-
     for run_attr_definition in metrics_data:
-        run_label_id_ = run_label_id(run_attr_definition.run_identifier)
+        run_label_id_ = _run_label_id(run_attr_definition.run_identifier)
         if run_label_id_ not in run_label_mapping:
             run_label_mapping[run_label_id_] = len(run_label_mapping)
             label_mapping.append(sys_id_label_mapping[run_label_id_])
@@ -248,7 +255,7 @@ def create_metrics_dataframe(
 
     def generate_categorized_rows() -> Generator[Tuple, None, None]:
         for attribute, points in metrics_data.items():
-            exp_category = run_label_mapping[run_label_id(attribute.run_identifier)]
+            exp_category = run_label_mapping[_run_label_id(attribute.run_identifier)]
             path_category = path_mapping[attribute.attribute_definition.name]
 
             for point in points:
@@ -318,9 +325,10 @@ def create_series_dataframe(
     label_mapping: list[str] = []
 
     for run_attr_definition in series_data.keys():
-        if run_attr_definition.run_identifier.sys_id not in experiment_mapping:
-            experiment_mapping[run_attr_definition.run_identifier.sys_id] = len(experiment_mapping)
-            label_mapping.append(sys_id_label_mapping[run_attr_definition.run_identifier.sys_id])
+        run_sys_id = _require_sys_id(run_attr_definition.run_identifier)
+        if run_sys_id not in experiment_mapping:
+            experiment_mapping[run_sys_id] = len(experiment_mapping)
+            label_mapping.append(sys_id_label_mapping[run_sys_id])
 
         if run_attr_definition.attribute_definition.name not in path_mapping:
             path_mapping[run_attr_definition.attribute_definition.name] = len(path_mapping)
@@ -329,7 +337,8 @@ def create_series_dataframe(
         run_attribute_definition: identifiers.RunAttributeDefinition, values: list[series.SeriesValue]
     ) -> list[series.SeriesValue]:
         if run_attribute_definition.attribute_definition.type == "file_series":
-            label = sys_id_label_mapping[run_attribute_definition.run_identifier.sys_id]
+            run_sys_id = _require_sys_id(run_attribute_definition.run_identifier)
+            label = sys_id_label_mapping[run_sys_id]
             return [
                 series.SeriesValue(
                     step=point.step,
@@ -359,7 +368,8 @@ def create_series_dataframe(
 
     def generate_categorized_rows() -> Generator[Tuple, None, None]:
         for attribute, values in series_data.items():
-            exp_category = experiment_mapping[attribute.run_identifier.sys_id]
+            run_sys_id = _require_sys_id(attribute.run_identifier)
+            exp_category = experiment_mapping[run_sys_id]
             path_category = path_mapping[attribute.attribute_definition.name]
             converted_values = convert_values(attribute, values)
 
@@ -414,20 +424,22 @@ def create_metric_buckets_dataframe(
     """
 
     path_mapping: dict[str, int] = {}
-    sys_id_mapping: dict[str, int] = {}
+    sys_id_mapping: dict[identifiers.SysId, int] = {}
     label_mapping: list[str] = []
 
     for run_attr_definition in buckets_data:
-        if run_attr_definition.run_identifier.sys_id not in sys_id_mapping:
-            sys_id_mapping[run_attr_definition.run_identifier.sys_id] = len(sys_id_mapping)
-            label_mapping.append(sys_id_label_mapping[run_attr_definition.run_identifier.sys_id])
+        run_sys_id = _require_sys_id(run_attr_definition.run_identifier)
+        if run_sys_id not in sys_id_mapping:
+            sys_id_mapping[run_sys_id] = len(sys_id_mapping)
+            label_mapping.append(sys_id_label_mapping[run_sys_id])
 
         if run_attr_definition.attribute_definition.name not in path_mapping:
             path_mapping[run_attr_definition.attribute_definition.name] = len(path_mapping)
 
     def generate_categorized_rows() -> Generator[Tuple, None, None]:
         for attribute, buckets in buckets_data.items():
-            exp_category = sys_id_mapping[attribute.run_identifier.sys_id]
+            run_sys_id = _require_sys_id(attribute.run_identifier)
+            exp_category = sys_id_mapping[run_sys_id]
             path_category = path_mapping[attribute.attribute_definition.name]
 
             buckets.sort(key=lambda b: (b.from_x, b.to_x))
@@ -475,7 +487,7 @@ def create_metric_buckets_dataframe(
             [
                 (
                     dim,
-                    sys_id_label_mapping[run_attr_definition.run_identifier.sys_id],
+                    sys_id_label_mapping[_require_sys_id(run_attr_definition.run_identifier)],
                     run_attr_definition.attribute_definition.name,
                 )
                 for run_attr_definition in buckets_data.keys()

--- a/src/neptune_query/internal/retrieval/metrics.py
+++ b/src/neptune_query/internal/retrieval/metrics.py
@@ -16,6 +16,7 @@
 import functools as ft
 from typing import (
     Any,
+    Literal,
     Optional,
     Union,
 )
@@ -59,6 +60,7 @@ def fetch_multiple_series_values(
     include_preview: bool,
     step_range: tuple[Union[float, None], Union[float, None]] = (None, None),
     tail_limit: Optional[int] = None,
+    run_identifier_mode: Literal["sys_id", "custom_run_id"] = "sys_id",
 ) -> dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]:
     if not run_attribute_definitions:
         return {}
@@ -79,7 +81,10 @@ def fetch_multiple_series_values(
                 "requestId": request_id,
                 "series": {
                     "holder": {
-                        "identifier": str(run_attribute.run_identifier),
+                        "identifier": _make_holder_identifier(
+                            run_attribute=run_attribute,
+                            run_identifier_mode=run_identifier_mode,
+                        ),
                         "type": "experiment",
                     },
                     "attribute": run_attribute.attribute_definition.name,
@@ -119,6 +124,17 @@ def fetch_multiple_series_values(
         results[attribute].reverse()
 
     return results
+
+
+def _make_holder_identifier(
+    run_attribute: identifiers.RunAttributeDefinition,
+    run_identifier_mode: Literal["sys_id", "custom_run_id"],
+) -> str:
+    if run_identifier_mode == "sys_id":
+        return str(run_attribute.run_identifier)
+    if run_identifier_mode == "custom_run_id":
+        return f"CUSTOM/{run_attribute.run_identifier.project_identifier}/{run_attribute.run_identifier.sys_id}"
+    raise ValueError(f"Unexpected run identifier mode: {run_identifier_mode}")
 
 
 def _fetch_metrics_page(

--- a/src/neptune_query/internal/retrieval/metrics.py
+++ b/src/neptune_query/internal/retrieval/metrics.py
@@ -16,7 +16,6 @@
 import functools as ft
 from typing import (
     Any,
-    Literal,
     Optional,
     Union,
 )
@@ -60,7 +59,6 @@ def fetch_multiple_series_values(
     include_preview: bool,
     step_range: tuple[Union[float, None], Union[float, None]] = (None, None),
     tail_limit: Optional[int] = None,
-    run_identifier_mode: Literal["sys_id", "custom_run_id"] = "sys_id",
 ) -> dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]:
     if not run_attribute_definitions:
         return {}
@@ -81,10 +79,7 @@ def fetch_multiple_series_values(
                 "requestId": request_id,
                 "series": {
                     "holder": {
-                        "identifier": _make_holder_identifier(
-                            run_attribute=run_attribute,
-                            run_identifier_mode=run_identifier_mode,
-                        ),
+                        "identifier": str(run_attribute.run_identifier),
                         "type": "experiment",
                     },
                     "attribute": run_attribute.attribute_definition.name,
@@ -124,17 +119,6 @@ def fetch_multiple_series_values(
         results[attribute].reverse()
 
     return results
-
-
-def _make_holder_identifier(
-    run_attribute: identifiers.RunAttributeDefinition,
-    run_identifier_mode: Literal["sys_id", "custom_run_id"],
-) -> str:
-    if run_identifier_mode == "sys_id":
-        return str(run_attribute.run_identifier)
-    if run_identifier_mode == "custom_run_id":
-        return f"CUSTOM/{run_attribute.run_identifier.project_identifier}/{run_attribute.run_identifier.sys_id}"
-    raise ValueError(f"Unexpected run identifier mode: {run_identifier_mode}")
 
 
 def _fetch_metrics_page(

--- a/src/neptune_query/runs.py
+++ b/src/neptune_query/runs.py
@@ -215,6 +215,8 @@ def fetch_metrics(
         project_identifier=project_identifier,
         filter_=runs_filter,
         attributes=attributes_filter,
+        exact_run_ids=runs if isinstance(runs, list) else None,
+        exact_attribute_names=attributes if isinstance(attributes, list) else None,
         include_time=include_time,
         step_range=step_range,
         lineage_to_the_root=lineage_to_the_root,

--- a/tests/e2e/v1/runs/test_runs_fetch_metrics.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_metrics.py
@@ -192,6 +192,17 @@ def project(ensure_project: EnsureProjectFunction) -> IngestedProjectData:
             False,
         ),
         (
+            ["linear_history_root", "linear_history_fork1"],
+            ["unique1/0", "unique2/0"],
+            {
+                ("linear_history_root", "unique1/0"): METRICS["linear_history_root"]["unique1/0"],
+                ("linear_history_fork1", "unique2/0"): METRICS["linear_history_fork1"]["unique2/0"],
+            },
+            None,
+            (None, None),
+            False,
+        ),
+        (
             r"^linear_history_(root|fork1)$",
             r"unique.*",
             {

--- a/tests/e2e/v1/runs/test_runs_fetch_metrics.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_metrics.py
@@ -311,6 +311,58 @@ def test_fetch_run_metrics(
     pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
 
 
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("include_time", ["absolute", None])
+def test_fetch_run_metrics_exact_list_non_existent_run_returns_empty_dataframe(
+    project: IngestedProjectData,
+    type_suffix_in_column_names: bool,
+    include_time: str | None,
+):
+    df = runs.fetch_metrics(
+        project=project.project_identifier,
+        runs=["non_existent_run_id_123456789"],
+        attributes=["foo0"],
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_time=include_time,
+    )
+
+    expected_df = build_expected_dataframe(
+        project,
+        expected_metrics={},
+        include_time=include_time,
+        type_suffix_in_column_names=type_suffix_in_column_names,
+    )
+
+    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("include_time", ["absolute", None])
+def test_fetch_run_metrics_exact_list_mixed_existing_and_non_existent_runs_returns_existing_only(
+    project: IngestedProjectData,
+    type_suffix_in_column_names: bool,
+    include_time: str | None,
+):
+    df = runs.fetch_metrics(
+        project=project.project_identifier,
+        runs=["linear_history_root", "non_existent_run_id_123456789"],
+        attributes=["foo0"],
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_time=include_time,
+    )
+
+    expected_df = build_expected_dataframe(
+        project,
+        expected_metrics={
+            ("linear_history_root", "foo0"): METRICS["linear_history_root"]["foo0"],
+        },
+        include_time=include_time,
+        type_suffix_in_column_names=type_suffix_in_column_names,
+    )
+
+    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+
 def build_expected_dataframe(
     project: IngestedProjectData,
     expected_metrics: dict[tuple[str, str], list[tuple[float, float]]],

--- a/tests/e2e/v1/runs/test_runs_fetch_metrics.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_metrics.py
@@ -42,6 +42,7 @@ METRICS: dict[str, dict[str, list[tuple[float, float]]]] = {
         "foo1": [(float(step), float(step * 0.8)) for step in range(9, 20)],
     },
 }
+NON_FLOAT_SERIES_ATTRIBUTE = "logs/status"
 
 
 @pytest.fixture(scope="module")
@@ -54,6 +55,9 @@ def project(ensure_project: EnsureProjectFunction) -> IngestedProjectData:
             experiment_name="linear-history",
             run_id="linear_history_root",
             float_series={name: dict(series) for name, series in METRICS["linear_history_root"].items()},
+            string_series={
+                NON_FLOAT_SERIES_ATTRIBUTE: {0.0: "started", 1.0: "running", 2.0: "finished"},
+            },
         ),
         RunData(
             experiment_name="linear-history",
@@ -356,6 +360,31 @@ def test_fetch_run_metrics_exact_list_mixed_existing_and_non_existent_runs_retur
         expected_metrics={
             ("linear_history_root", "foo0"): METRICS["linear_history_root"]["foo0"],
         },
+        include_time=include_time,
+        type_suffix_in_column_names=type_suffix_in_column_names,
+    )
+
+    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("include_time", ["absolute", None])
+def test_fetch_run_metrics_exact_list_existing_non_float_attribute_returns_empty_dataframe(
+    project: IngestedProjectData,
+    type_suffix_in_column_names: bool,
+    include_time: str | None,
+):
+    df = runs.fetch_metrics(
+        project=project.project_identifier,
+        runs=["linear_history_root"],
+        attributes=[NON_FLOAT_SERIES_ATTRIBUTE],
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_time=include_time,
+    )
+
+    expected_df = build_expected_dataframe(
+        project,
+        expected_metrics={},
         include_time=include_time,
         type_suffix_in_column_names=type_suffix_in_column_names,
     )

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -379,6 +379,94 @@ def test__fetch_metrics_unique__output_format_variants(
     assert {t[0] for t in result.index.tolist()} == filtered_experiments
 
 
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("include_time", [None, "absolute"])
+def test__fetch_metrics_exact_list_non_existent_experiment_returns_empty_dataframe(
+    project: IngestedProjectData,
+    type_suffix_in_column_names: bool,
+    include_time: Union[Literal["absolute"], None],
+):
+    df = fetch_metrics(
+        project=project.project_identifier,
+        experiments=["non-existent-experiment-123456789"],
+        attributes=["train/metrics/value_0"],
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_time=include_time,
+    )
+
+    expected = create_metrics_dataframe(
+        metrics_data={},
+        sys_id_label_mapping={},
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_point_previews=False,
+        timestamp_column_name="absolute_time" if include_time == "absolute" else None,
+        index_column_name="experiment",
+    )
+
+    pd.testing.assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("include_time", [None, "absolute"])
+def test__fetch_metrics_exact_list_mixed_existing_and_non_existent_experiments_returns_existing_only(
+    project: IngestedProjectData,
+    type_suffix_in_column_names: bool,
+    include_time: Union[Literal["absolute"], None],
+):
+    target_run = next(run for run in project.ingested_runs if run.experiment_name == EXPERIMENT_NAMES[0])
+    metric_name = "train/metrics/value_0"
+
+    df = fetch_metrics(
+        project=project.project_identifier,
+        experiments=[EXPERIMENT_NAMES[0], "non-existent-experiment-123456789"],
+        attributes=[metric_name],
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_time=include_time,
+    )
+
+    expected = create_metrics_dataframe(
+        metrics_data={
+            _to_run_attribute_definition(project.project_identifier, target_run.run_id, metric_name): [
+                _to_float_point_value(step, value) for step, value in target_run.float_series[metric_name].items()
+            ]
+        },
+        sys_id_label_mapping={SysId(target_run.run_id): target_run.experiment_name},
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_point_previews=False,
+        timestamp_column_name="absolute_time" if include_time == "absolute" else None,
+        index_column_name="experiment",
+    )
+
+    pd.testing.assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("include_time", [None, "absolute"])
+def test__fetch_metrics_exact_list_missing_attribute_returns_empty_dataframe(
+    project: IngestedProjectData,
+    type_suffix_in_column_names: bool,
+    include_time: Union[Literal["absolute"], None],
+):
+    df = fetch_metrics(
+        project=project.project_identifier,
+        experiments=[EXPERIMENT_NAMES[0]],
+        attributes=["train/metrics/non-existent-attribute-123456789"],
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_time=include_time,
+    )
+
+    expected = create_metrics_dataframe(
+        metrics_data={},
+        sys_id_label_mapping={},
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_point_previews=False,
+        timestamp_column_name="absolute_time" if include_time == "absolute" else None,
+        index_column_name="experiment",
+    )
+
+    pd.testing.assert_frame_equal(df, expected)
+
+
 @pytest.mark.parametrize(
     "lineage_to_the_root,expected_values",
     [

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -37,6 +37,7 @@ from tests.e2e.data_ingestion import (
 METRIC_STEPS = 6
 EXPERIMENT_NAMES = ["metrics-alpha", "metrics-beta", "metrics-gamma"]
 INF_NAN_EXPERIMENT_NAME = "metrics-inf-nan"
+NON_FLOAT_SERIES_ATTRIBUTE = "train/logs/status"
 
 INF_SERIES_VALUES = [float("inf"), 1.0, float("-inf"), 3.0, 4.0, float("inf"), 6.0, float("-inf"), 8.0, 9.0]
 NAN_SERIES_VALUES = [float("nan"), 1.0, float("nan"), 3.0, 4.0, float("nan"), 6.0, float("nan"), 8.0, 9.0]
@@ -68,6 +69,9 @@ def project(ensure_project: EnsureProjectFunction) -> IngestedProjectData:
                 float_series={
                     "train/metrics/value_0": {float(step): float(step) * 0.1 for step in range(METRIC_STEPS)},
                     "train/metrics/value_1": {float(step): float(step) * 0.2 + 0.5 for step in range(METRIC_STEPS)},
+                },
+                string_series={
+                    NON_FLOAT_SERIES_ATTRIBUTE: {float(step): f"status-{step}" for step in range(METRIC_STEPS)},
                 },
             ),
             RunData(
@@ -451,6 +455,33 @@ def test__fetch_metrics_exact_list_missing_attribute_returns_empty_dataframe(
         project=project.project_identifier,
         experiments=[EXPERIMENT_NAMES[0]],
         attributes=["train/metrics/non-existent-attribute-123456789"],
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_time=include_time,
+    )
+
+    expected = create_metrics_dataframe(
+        metrics_data={},
+        sys_id_label_mapping={},
+        type_suffix_in_column_names=type_suffix_in_column_names,
+        include_point_previews=False,
+        timestamp_column_name="absolute_time" if include_time == "absolute" else None,
+        index_column_name="experiment",
+    )
+
+    pd.testing.assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("include_time", [None, "absolute"])
+def test__fetch_metrics_exact_list_existing_non_float_attribute_returns_empty_dataframe(
+    project: IngestedProjectData,
+    type_suffix_in_column_names: bool,
+    include_time: Union[Literal["absolute"], None],
+):
+    df = fetch_metrics(
+        project=project.project_identifier,
+        experiments=[EXPERIMENT_NAMES[0]],
+        attributes=[NON_FLOAT_SERIES_ATTRIBUTE],
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_time=include_time,
     )

--- a/tests/unit/internal/retrieval/test_metrics.py
+++ b/tests/unit/internal/retrieval/test_metrics.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+from neptune_query.internal.identifiers import (
+    AttributeDefinition,
+    ProjectIdentifier,
+    RunAttributeDefinition,
+    RunIdentifier,
+    SysId,
+)
+from neptune_query.internal.retrieval import metrics
+from neptune_query.internal.retrieval.search import ContainerType
+
+
+def _run_attribute(project: str, run_id: str) -> RunAttributeDefinition:
+    return RunAttributeDefinition(
+        run_identifier=RunIdentifier(
+            project_identifier=ProjectIdentifier(project),
+            sys_id=SysId(run_id),
+        ),
+        attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+    )
+
+
+def test_fetch_multiple_series_values_uses_custom_holder_identifier():
+    run_attribute = _run_attribute(project="my-org/my-project", run_id="my-run-id")
+    captured_params = {}
+
+    def fake_fetch_pages(**kwargs):
+        captured_params["initial_params"] = kwargs["initial_params"]
+        return iter([])
+
+    with patch("neptune_query.internal.retrieval.metrics.util.fetch_pages", side_effect=fake_fetch_pages):
+        result = metrics.fetch_multiple_series_values(
+            client=None,
+            run_attribute_definitions=[run_attribute],
+            include_inherited=False,
+            container_type=ContainerType.RUN,
+            include_preview=False,
+            run_identifier_mode="custom_run_id",
+        )
+
+    assert result == {run_attribute: []}
+    request = captured_params["initial_params"]["requests"][0]
+    assert request["series"]["holder"]["identifier"] == "CUSTOM/my-org/my-project/my-run-id"
+    assert request["series"]["holder"]["type"] == "experiment"
+
+
+def test_fetch_multiple_series_values_default_identifier_uses_project_and_sys_id():
+    run_attribute = _run_attribute(project="my-org/my-project", run_id="sysid-123")
+    captured_params = {}
+
+    def fake_fetch_pages(**kwargs):
+        captured_params["initial_params"] = kwargs["initial_params"]
+        return iter([])
+
+    with patch("neptune_query.internal.retrieval.metrics.util.fetch_pages", side_effect=fake_fetch_pages):
+        result = metrics.fetch_multiple_series_values(
+            client=None,
+            run_attribute_definitions=[run_attribute],
+            include_inherited=False,
+            container_type=ContainerType.RUN,
+            include_preview=False,
+        )
+
+    assert result == {run_attribute: []}
+    request = captured_params["initial_params"]["requests"][0]
+    assert request["series"]["holder"]["identifier"] == "my-org/my-project/sysid-123"

--- a/tests/unit/internal/retrieval/test_metrics.py
+++ b/tests/unit/internal/retrieval/test_metrics.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from neptune_query.internal.identifiers import (
     AttributeDefinition,
+    CustomRunId,
     ProjectIdentifier,
     RunAttributeDefinition,
     RunIdentifier,
@@ -11,18 +12,23 @@ from neptune_query.internal.retrieval import metrics
 from neptune_query.internal.retrieval.search import ContainerType
 
 
-def _run_attribute(project: str, run_id: str) -> RunAttributeDefinition:
+def _run_attribute(project: str, run_id: str, custom_run_id: str | None = None) -> RunAttributeDefinition:
     return RunAttributeDefinition(
         run_identifier=RunIdentifier(
             project_identifier=ProjectIdentifier(project),
             sys_id=SysId(run_id),
+            custom_run_id=CustomRunId(custom_run_id) if custom_run_id is not None else None,
         ),
         attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
     )
 
 
 def test_fetch_multiple_series_values_uses_custom_holder_identifier():
-    run_attribute = _run_attribute(project="my-org/my-project", run_id="my-run-id")
+    run_attribute = _run_attribute(
+        project="my-org/my-project",
+        run_id="sysid-123",
+        custom_run_id="my-run-id",
+    )
     captured_params = {}
 
     def fake_fetch_pages(**kwargs):
@@ -36,7 +42,6 @@ def test_fetch_multiple_series_values_uses_custom_holder_identifier():
             include_inherited=False,
             container_type=ContainerType.RUN,
             include_preview=False,
-            run_identifier_mode="custom_run_id",
         )
 
     assert result == {run_attribute: []}

--- a/tests/unit/internal/retrieval/test_metrics.py
+++ b/tests/unit/internal/retrieval/test_metrics.py
@@ -12,13 +12,22 @@ from neptune_query.internal.retrieval import metrics
 from neptune_query.internal.retrieval.search import ContainerType
 
 
-def _run_attribute(project: str, run_id: str, custom_run_id: str | None = None) -> RunAttributeDefinition:
-    return RunAttributeDefinition(
-        run_identifier=RunIdentifier(
+def _run_attribute(project: str, run_id: str | None = None, custom_run_id: str | None = None) -> RunAttributeDefinition:
+    if custom_run_id is not None:
+        run_identifier = RunIdentifier(
+            project_identifier=ProjectIdentifier(project),
+            custom_run_id=CustomRunId(custom_run_id),
+        )
+    else:
+        if run_id is None:
+            raise ValueError("run_id is required when custom_run_id is not provided")
+        run_identifier = RunIdentifier(
             project_identifier=ProjectIdentifier(project),
             sys_id=SysId(run_id),
-            custom_run_id=CustomRunId(custom_run_id) if custom_run_id is not None else None,
-        ),
+        )
+
+    return RunAttributeDefinition(
+        run_identifier=run_identifier,
         attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
     )
 
@@ -26,7 +35,6 @@ def _run_attribute(project: str, run_id: str, custom_run_id: str | None = None) 
 def test_fetch_multiple_series_values_uses_custom_holder_identifier():
     run_attribute = _run_attribute(
         project="my-org/my-project",
-        run_id="sysid-123",
         custom_run_id="my-run-id",
     )
     captured_params = {}

--- a/tests/unit/internal/test_output_format.py
+++ b/tests/unit/internal/test_output_format.py
@@ -23,6 +23,7 @@ from neptune_query.internal import (
 )
 from neptune_query.internal.identifiers import (
     AttributeDefinition,
+    CustomRunId,
     ProjectIdentifier,
     RunAttributeDefinition,
     RunIdentifier,
@@ -701,6 +702,38 @@ def test_create_metrics_dataframe_from_exp_with_no_points_preview():
             names=["experiment", "step"],
         ),
     )
+    assert_frame_equal(df, expected_df)
+
+
+def test_create_metrics_dataframe_uses_custom_run_id_mapping_for_run_fast_path():
+    data = {
+        RunAttributeDefinition(
+            RunIdentifier(
+                project_identifier=ProjectIdentifier("foo/bar"),
+                custom_run_id=CustomRunId("run-1"),
+            ),
+            AttributeDefinition("path1", "float_series"),
+        ): [
+            (_make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
+        ],
+    }
+
+    df = create_metrics_dataframe(
+        metrics_data=data,
+        sys_id_label_mapping={CustomRunId("run-1"): "run-1"},
+        type_suffix_in_column_names=False,
+        include_point_previews=False,
+        index_column_name="run",
+    )
+
+    expected_df = pd.DataFrame(
+        data={"path1": [10.0]},
+        index=pd.MultiIndex.from_tuples(
+            tuples=[("run-1", 1.0)],
+            names=["run", "step"],
+        ),
+    )
+
     assert_frame_equal(df, expected_df)
 
 

--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -14,6 +14,7 @@ from neptune_query.internal import context
 from neptune_query.internal.env import NEPTUNE_QUERY_ENTRIES_SEARCH_MAX_PROJECTION_ATTRIBUTES
 from neptune_query.internal.identifiers import (
     AttributeDefinition,
+    CustomRunId,
     ProjectIdentifier,
     RunAttributeDefinition,
     RunIdentifier,
@@ -24,6 +25,7 @@ from neptune_query.internal.retrieval import util
 from neptune_query.internal.retrieval.search import (
     ContainerType,
     ExperimentSysAttrs,
+    RunSysAttrs,
 )
 
 
@@ -332,11 +334,211 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
                 include_preview=ANY,
                 step_range=ANY,
                 tail_limit=ANY,
+                run_identifier_mode=ANY,
             )
             for start, end in _edges(expected_calls)
         ],
         any_order=True,
     )
+
+
+def test_fetch_metrics_uses_fast_path_for_exact_attribute_list():
+    project = ProjectIdentifier("project")
+    context.set_api_token("irrelevant")
+    experiments = [ExperimentSysAttrs(sys_id=SysId("sysid0"), sys_name=SysName("irrelevant"))]
+
+    with (
+        patch("neptune_query.internal.composition.fetch_metrics._client"),
+        patch("neptune_query.internal.retrieval.search.fetch_experiment_sys_attrs") as fetch_experiment_sys_attrs,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_attribute_definitions_split") as fetch_defs_split,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_multiple_series_values") as fetch_series_values,
+    ):
+        fetch_experiment_sys_attrs.side_effect = lambda **kwargs: iter([util.Page(experiments)])
+        fetch_series_values.return_value = {}
+
+        df = npt.fetch_metrics(
+            project=project,
+            experiments="ignored",
+            attributes=["metric/a", "metric/a", "metric/b"],
+        )
+
+    assert df.empty
+    fetch_defs_split.assert_not_called()
+    fetch_series_values.assert_called_once()
+    assert set(fetch_series_values.call_args.kwargs["run_attribute_definitions"]) == {
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=experiments[0].sys_id),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        ),
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=experiments[0].sys_id),
+            attribute_definition=AttributeDefinition(name="metric/b", type="float_series"),
+        ),
+    }
+    assert len(fetch_series_values.call_args.kwargs["run_attribute_definitions"]) == 2
+
+
+def test_fetch_runs_metrics_uses_fast_path_for_exact_attribute_list():
+    project = ProjectIdentifier("project")
+    context.set_api_token("irrelevant")
+
+    with (
+        patch("neptune_query.internal.composition.fetch_metrics._client"),
+        patch("neptune_query.internal.retrieval.search.fetch_run_sys_attrs") as fetch_run_sys_attrs,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_attribute_definitions_split") as fetch_defs_split,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_multiple_series_values") as fetch_series_values,
+    ):
+        fetch_series_values.return_value = {}
+
+        df = nq_runs.fetch_metrics(
+            project=project,
+            runs=["run-0"],
+            attributes=["metric/a"],
+        )
+
+    assert df.empty
+    fetch_run_sys_attrs.assert_not_called()
+    fetch_defs_split.assert_not_called()
+    fetch_series_values.assert_called_once()
+    assert fetch_series_values.call_args.kwargs["run_identifier_mode"] == "custom_run_id"
+    assert fetch_series_values.call_args.kwargs["run_attribute_definitions"] == [
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-0")),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        )
+    ]
+
+
+def test_fetch_runs_metrics_fast_path_deduplicates_runs_and_attributes():
+    project = ProjectIdentifier("project")
+    context.set_api_token("irrelevant")
+
+    with (
+        patch("neptune_query.internal.composition.fetch_metrics._client"),
+        patch("neptune_query.internal.retrieval.search.fetch_run_sys_attrs") as fetch_run_sys_attrs,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_attribute_definitions_split") as fetch_defs_split,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_multiple_series_values") as fetch_series_values,
+    ):
+        fetch_series_values.return_value = {}
+
+        df = nq_runs.fetch_metrics(
+            project=project,
+            runs=["run-2", "run-1", "run-2"],
+            attributes=["metric/b", "metric/a", "metric/b"],
+        )
+
+    assert df.empty
+    fetch_run_sys_attrs.assert_not_called()
+    fetch_defs_split.assert_not_called()
+    fetch_series_values.assert_called_once()
+    assert fetch_series_values.call_args.kwargs["run_identifier_mode"] == "custom_run_id"
+    assert set(fetch_series_values.call_args.kwargs["run_attribute_definitions"]) == {
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-2")),
+            attribute_definition=AttributeDefinition(name="metric/b", type="float_series"),
+        ),
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-2")),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        ),
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-1")),
+            attribute_definition=AttributeDefinition(name="metric/b", type="float_series"),
+        ),
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-1")),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        ),
+    }
+    assert len(fetch_series_values.call_args.kwargs["run_attribute_definitions"]) == 4
+
+
+def test_fetch_runs_metrics_with_non_exact_runs_uses_sys_id_based_path():
+    project = ProjectIdentifier("project")
+    context.set_api_token("irrelevant")
+    runs = [RunSysAttrs(sys_id=SysId("sysid0"), sys_custom_run_id=CustomRunId("run-0"))]
+
+    with (
+        patch("neptune_query.internal.composition.fetch_metrics._client"),
+        patch("neptune_query.internal.retrieval.search.fetch_run_sys_attrs") as fetch_run_sys_attrs,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_attribute_definitions_split") as fetch_defs_split,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_multiple_series_values") as fetch_series_values,
+    ):
+        fetch_run_sys_attrs.side_effect = lambda **kwargs: iter([util.Page(runs)])
+        fetch_series_values.return_value = {}
+
+        df = nq_runs.fetch_metrics(
+            project=project,
+            runs="ignored",
+            attributes=["metric/a"],
+        )
+
+    assert df.empty
+    fetch_run_sys_attrs.assert_called()
+    fetch_defs_split.assert_not_called()
+    fetch_series_values.assert_called_once()
+    assert fetch_series_values.call_args.kwargs.get("run_identifier_mode", "sys_id") == "sys_id"
+    assert fetch_series_values.call_args.kwargs["run_attribute_definitions"] == [
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(project_identifier=project, sys_id=runs[0].sys_id),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        )
+    ]
+
+
+def test_fetch_metrics_fast_path_failure_is_propagated():
+    project = ProjectIdentifier("project")
+    context.set_api_token("irrelevant")
+    experiments = [ExperimentSysAttrs(sys_id=SysId("sysid0"), sys_name=SysName("irrelevant"))]
+
+    with (
+        patch("neptune_query.internal.composition.fetch_metrics._client"),
+        patch("neptune_query.internal.retrieval.search.fetch_experiment_sys_attrs") as fetch_experiment_sys_attrs,
+        patch(
+            "neptune_query.internal.composition.fetch_metrics.fetch_multiple_series_values"
+        ) as fetch_multiple_series_values,
+    ):
+        fetch_experiment_sys_attrs.side_effect = lambda **kwargs: iter([util.Page(experiments)])
+        fetch_multiple_series_values.side_effect = RuntimeError("fast path failed")
+
+        with pytest.raises(RuntimeError, match="fast path failed"):
+            npt.fetch_metrics(
+                project=project,
+                experiments="ignored",
+                attributes=["metric/a"],
+            )
+
+    fetch_multiple_series_values.assert_called_once()
+
+
+def test_fetch_metrics_attribute_filter_exact_names_uses_existing_path():
+    project = ProjectIdentifier("project")
+    context.set_api_token("irrelevant")
+    experiments = [ExperimentSysAttrs(sys_id=SysId("sysid0"), sys_name=SysName("irrelevant"))]
+    attributes = [AttributeDefinition(name="metric/a", type="float_series")]
+
+    with (
+        patch("neptune_query.internal.composition.fetch_metrics._client"),
+        patch("neptune_query.internal.retrieval.search.fetch_experiment_sys_attrs") as fetch_experiment_sys_attrs,
+        patch(
+            "neptune_query.internal.retrieval.attribute_definitions.fetch_attribute_definitions_single_filter"
+        ) as fetch_attribute_definitions_single_filter,
+        patch(
+            "neptune_query.internal.composition.fetch_metrics.fetch_multiple_series_values"
+        ) as fetch_multiple_series_values,
+    ):
+        fetch_experiment_sys_attrs.side_effect = lambda **kwargs: iter([util.Page(experiments)])
+        fetch_attribute_definitions_single_filter.side_effect = lambda **kwargs: iter([util.Page(attributes)])
+        fetch_multiple_series_values.return_value = {}
+
+        df = npt.fetch_metrics(
+            project=project,
+            experiments="ignored",
+            attributes=AttributeFilter(name=["metric/a"]),
+        )
+
+    assert df.empty
+    fetch_attribute_definitions_single_filter.assert_called()
 
 
 def test_fetch_experiments_table_uses_entries_search_fast_path_for_exact_attribute_list():

--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -334,7 +334,6 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
                 include_preview=ANY,
                 step_range=ANY,
                 tail_limit=ANY,
-                run_identifier_mode=ANY,
             )
             for start, end in _edges(expected_calls)
         ],
@@ -400,10 +399,13 @@ def test_fetch_runs_metrics_uses_fast_path_for_exact_attribute_list():
     fetch_run_sys_attrs.assert_not_called()
     fetch_defs_split.assert_not_called()
     fetch_series_values.assert_called_once()
-    assert fetch_series_values.call_args.kwargs["run_identifier_mode"] == "custom_run_id"
     assert fetch_series_values.call_args.kwargs["run_attribute_definitions"] == [
         RunAttributeDefinition(
-            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-0")),
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-0"),
+                custom_run_id=CustomRunId("run-0"),
+            ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
         )
     ]
@@ -431,22 +433,37 @@ def test_fetch_runs_metrics_fast_path_deduplicates_runs_and_attributes():
     fetch_run_sys_attrs.assert_not_called()
     fetch_defs_split.assert_not_called()
     fetch_series_values.assert_called_once()
-    assert fetch_series_values.call_args.kwargs["run_identifier_mode"] == "custom_run_id"
     assert set(fetch_series_values.call_args.kwargs["run_attribute_definitions"]) == {
         RunAttributeDefinition(
-            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-2")),
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-2"),
+                custom_run_id=CustomRunId("run-2"),
+            ),
             attribute_definition=AttributeDefinition(name="metric/b", type="float_series"),
         ),
         RunAttributeDefinition(
-            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-2")),
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-2"),
+                custom_run_id=CustomRunId("run-2"),
+            ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
         ),
         RunAttributeDefinition(
-            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-1")),
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-1"),
+                custom_run_id=CustomRunId("run-1"),
+            ),
             attribute_definition=AttributeDefinition(name="metric/b", type="float_series"),
         ),
         RunAttributeDefinition(
-            run_identifier=RunIdentifier(project_identifier=project, sys_id=SysId("run-1")),
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-1"),
+                custom_run_id=CustomRunId("run-1"),
+            ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
         ),
     }
@@ -477,7 +494,6 @@ def test_fetch_runs_metrics_with_non_exact_runs_uses_sys_id_based_path():
     fetch_run_sys_attrs.assert_called()
     fetch_defs_split.assert_not_called()
     fetch_series_values.assert_called_once()
-    assert fetch_series_values.call_args.kwargs.get("run_identifier_mode", "sys_id") == "sys_id"
     assert fetch_series_values.call_args.kwargs["run_attribute_definitions"] == [
         RunAttributeDefinition(
             run_identifier=RunIdentifier(project_identifier=project, sys_id=runs[0].sys_id),

--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -470,6 +470,63 @@ def test_fetch_runs_metrics_fast_path_deduplicates_runs_and_attributes():
     assert len(fetch_series_values.call_args.kwargs["run_attribute_definitions"]) == 4
 
 
+def test_fetch_runs_metrics_fast_path_respects_sys_id_batch_splitting(monkeypatch):
+    project = ProjectIdentifier("project")
+    context.set_api_token("irrelevant")
+    monkeypatch.setenv("NEPTUNE_QUERY_MAX_REQUEST_SIZE", "50")
+
+    with (
+        patch("neptune_query.internal.composition.fetch_metrics._client"),
+        patch("neptune_query.internal.retrieval.search.fetch_run_sys_attrs") as fetch_run_sys_attrs,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_attribute_definitions_split") as fetch_defs_split,
+        patch("neptune_query.internal.composition.fetch_metrics.fetch_multiple_series_values") as fetch_series_values,
+    ):
+        fetch_series_values.return_value = {}
+
+        df = nq_runs.fetch_metrics(
+            project=project,
+            runs=["run-0", "run-1", "run-2"],
+            attributes=["metric/a"],
+        )
+
+    assert df.empty
+    fetch_run_sys_attrs.assert_not_called()
+    fetch_defs_split.assert_not_called()
+    assert fetch_series_values.call_count == 3
+
+    all_run_attribute_definitions = [
+        run_attribute_definition
+        for call_args in fetch_series_values.call_args_list
+        for run_attribute_definition in call_args.kwargs["run_attribute_definitions"]
+    ]
+    assert set(all_run_attribute_definitions) == {
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-0"),
+                custom_run_id=CustomRunId("run-0"),
+            ),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        ),
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-1"),
+                custom_run_id=CustomRunId("run-1"),
+            ),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        ),
+        RunAttributeDefinition(
+            run_identifier=RunIdentifier(
+                project_identifier=project,
+                sys_id=SysId("run-2"),
+                custom_run_id=CustomRunId("run-2"),
+            ),
+            attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
+        ),
+    }
+
+
 def test_fetch_runs_metrics_with_non_exact_runs_uses_sys_id_based_path():
     project = ProjectIdentifier("project")
     context.set_api_token("irrelevant")

--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -403,7 +403,6 @@ def test_fetch_runs_metrics_uses_fast_path_for_exact_attribute_list():
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-0"),
                 custom_run_id=CustomRunId("run-0"),
             ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
@@ -437,7 +436,6 @@ def test_fetch_runs_metrics_fast_path_deduplicates_runs_and_attributes():
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-2"),
                 custom_run_id=CustomRunId("run-2"),
             ),
             attribute_definition=AttributeDefinition(name="metric/b", type="float_series"),
@@ -445,7 +443,6 @@ def test_fetch_runs_metrics_fast_path_deduplicates_runs_and_attributes():
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-2"),
                 custom_run_id=CustomRunId("run-2"),
             ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
@@ -453,7 +450,6 @@ def test_fetch_runs_metrics_fast_path_deduplicates_runs_and_attributes():
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-1"),
                 custom_run_id=CustomRunId("run-1"),
             ),
             attribute_definition=AttributeDefinition(name="metric/b", type="float_series"),
@@ -461,7 +457,6 @@ def test_fetch_runs_metrics_fast_path_deduplicates_runs_and_attributes():
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-1"),
                 custom_run_id=CustomRunId("run-1"),
             ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
@@ -503,7 +498,6 @@ def test_fetch_runs_metrics_fast_path_respects_sys_id_batch_splitting(monkeypatc
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-0"),
                 custom_run_id=CustomRunId("run-0"),
             ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
@@ -511,7 +505,6 @@ def test_fetch_runs_metrics_fast_path_respects_sys_id_batch_splitting(monkeypatc
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-1"),
                 custom_run_id=CustomRunId("run-1"),
             ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),
@@ -519,7 +512,6 @@ def test_fetch_runs_metrics_fast_path_respects_sys_id_batch_splitting(monkeypatc
         RunAttributeDefinition(
             run_identifier=RunIdentifier(
                 project_identifier=project,
-                sys_id=SysId("run-2"),
                 custom_run_id=CustomRunId("run-2"),
             ),
             attribute_definition=AttributeDefinition(name="metric/a", type="float_series"),


### PR DESCRIPTION
 This commit optimizes fetch_metrics when both runs and attributes are provided as exact lists.
- Added a fast path in internal/composition/fetch_metrics.py that skips expensive sys-attrs/attribute-definition lookup flows for exact run+attribute inputs, and deduplicates run/attribute values.
- Added run_identifier_mode to internal/retrieval/metrics.py so series requests can use either default sys-id holder identifiers or CUSTOM/{project}/{run_id} identifiers.
- Wired exact-list hints from public APIs:
    - neptune_query.fetch_metrics(...) now passes exact attribute names when attributes is a list.
    - neptune_query.runs.fetch_metrics(...) now passes exact run IDs and exact attribute names when both are lists.

Test coverage added/updated:
- New unit tests for holder identifier generation (tests/unit/internal/retrieval/test_metrics.py).
- Extended split/composition tests for fast-path selection, deduplication, fallback behavior, and error propagation (tests/unit/v1/test_split.py).
- Added e2e coverage for exact run + exact attribute list scenario in runs metrics fetching (tests/e2e/v1/runs/test_runs_fetch_metrics.py).
